### PR TITLE
Sync upstream language and player changes

### DIFF
--- a/langs/EN.json
+++ b/langs/EN.json
@@ -41,6 +41,8 @@
     "statsMemory": "Memory Usage",
     "statsGuilds": "Servers",
     "statsUsers": "Users",
+    "guildStats": "This server has played {0} tracks with {1} listeners.",
+    "guildStatsNoData": "No statistics are available for this server.",
     "addEffect": "Applied the `{0}` effect.",
     "clearEffect": "The sound effects have been cleared!",
     "filterTagAlreadyInUse": "This sound effect is already in use! Please use /cleareffect <Tag> to remove it.",

--- a/voicelink/player.py
+++ b/voicelink/player.py
@@ -378,6 +378,7 @@ class Player(VoiceProtocol):
 
         if isinstance(event, TrackEndEvent) and event.reason != "replaced":
             self._current = None
+            create_task(func.track_end_stats(self.guild.id, event.track))
         
         if isinstance(event, TrackExceptionEvent) and event.exception["message"] == "This content isn’t available.":
             if self._node.yt_ratelimit:
@@ -387,6 +388,7 @@ class Player(VoiceProtocol):
 
         if isinstance(event, TrackStartEvent):
             self._ending_track = self._current
+            create_task(func.track_start_stats(self.guild.id, self._current))
             if self.crossfade_duration > 0:
                 if self._crossfade_task:
                     self._crossfade_task.cancel()


### PR DESCRIPTION
## Summary
- merge upstream translations and add guild stats strings in EN.json
- preserve track start/end metrics hooks while applying upstream player updates

## Testing
- `python -m json.tool langs/EN.json`
- `python -m py_compile voicelink/player.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1351d61a0832299433cb4cc1d1d0f